### PR TITLE
Feature: CLI args + equity metrics (MDD, Sharpe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Run:
 `python bot.py`
 
 Trades (if any) will be saved to `trades.csv`.
+
+## CLI
+Run with custom params:
+`python bot.py --symbol ETH/USDT --timeframe 15m --fast 10 --slow 30 --start-usd 1500`
+
+Backtest summary:
+`python backtest.py`

--- a/backtest.py
+++ b/backtest.py
@@ -1,37 +1,31 @@
 import numpy as np
 import pandas as pd
-
 from bot import run
 
-
-def max_drawdown(equity_curve: pd.Series) -> float:
-    peak = equity_curve.cummax()
-    dd = (equity_curve - peak) / peak
+def max_drawdown(equity: pd.Series) -> float:
+    peak = equity.cummax()
+    dd = (equity - peak) / peak
     return float(dd.min())
 
-
-def sharpe(returns: pd.Series, rf: float = 0.0) -> float:
-    if returns.std(ddof=0) == 0:
+def sharpe(equity: pd.Series, rf: float = 0.0) -> float:
+    rets = equity.pct_change().dropna()
+    if rets.empty or rets.std(ddof=0) == 0:
         return 0.0
-    return float((returns.mean() - rf) / returns.std(ddof=0) * np.sqrt(252 * 24 * 12))  # rough scale for 5m
-
+    # scale roughly for 5m candles (~12 per hour * 24 * 252 trading days)
+    scale = np.sqrt(12*24*252)
+    return float(((rets.mean() - rf) / rets.std(ddof=0)) * scale)
 
 def main():
-    equity, trades = run()
+    final_eq, trades, equity_curve = run()
     print("=== Backtest summary ===")
-    if trades is not None and not trades.empty:
-        # Build a rough equity curve from trades assuming last price marks-to-market
-        cash = []
-        bal = 1000.0
-        for _ in trades.itertuples(index=False):
-            # Not precise; for quick sanity only
-            pass
-        # Minimal outputs for now:
-        print(f"Trades: {len(trades)}")
+    print(f"Final equity: {final_eq:.2f} USD")
+    print(f"Trades: {0 if trades is None else len(trades)}")
+    if equity_curve is not None and not equity_curve.empty:
+        print(f"Max drawdown: {max_drawdown(equity_curve):.2%}")
+        print(f"Sharpe (rough): {sharpe(equity_curve):.2f}")
     else:
-        print("No trades executed.")
+        print("No equity curve available.")
     print("Done.")
-
 
 if __name__ == "__main__":
     main()

--- a/bot.py
+++ b/bot.py
@@ -1,38 +1,63 @@
+import argparse
 import pandas as pd
-
 from data import fetch_ohlcv
 from strategy import sma_crossover
 from paper_broker import PaperBroker
 
-
-def run(symbol="BTC/USDT", timeframe="5m", limit=500, fast=20, slow=50, start_usd=1000.0):
-    df = fetch_ohlcv(symbol, timeframe, limit, "binance")
+def run(symbol="BTC/USDT", timeframe="5m", limit=500, fast=20, slow=50, start_usd=1000.0, exchange="binance"):
+    df = fetch_ohlcv(symbol, timeframe, limit, exchange)
     df = sma_crossover(df, fast, slow)
     broker = PaperBroker(starting_usd=start_usd)
 
     prev = 0
+    equity_points = []
     for _, row in df.iterrows():
         sig = int(row["signal"])
-        if pd.isna(row["sma_fast"]) or pd.isna(row["sma_slow"]):
+        if pd.isna(row.get("sma_fast")) or pd.isna(row.get("sma_slow")):
+            equity_points.append((row["ts"], broker.equity(row["close"])))
             continue
         if sig == 1 and prev <= 0:
             broker.buy_all(row["close"], row["ts"])
         elif sig == -1 and prev >= 0:
             broker.sell_all(row["close"], row["ts"])
         prev = sig
+        equity_points.append((row["ts"], broker.equity(row["close"])))
 
-    # Close open position at last price
     last_price = float(df["close"].iloc[-1])
-    equity = broker.equity(last_price)
+    final_equity = broker.equity(last_price)
 
-    # Save trades
     trades = pd.DataFrame(broker.trades)
     if not trades.empty:
         trades.to_csv("trades.csv", index=False)
 
-    print(f"Final equity: {equity:.2f} USD | Trades: {len(broker.trades)}")
-    return equity, trades if not trades.empty else pd.DataFrame()
+    equity_curve = pd.Series(
+        [v for _, v in equity_points],
+        index=[t for t, _ in equity_points],
+        name="equity"
+    )
 
+    print(f"[{symbol} {timeframe}] Final equity: {final_equity:.2f} USD | Trades: {len(broker.trades)}")
+    return final_equity, trades if not trades.empty else pd.DataFrame(), equity_curve
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Paper-trading SMA bot")
+    p.add_argument("--symbol", default="BTC/USDT")
+    p.add_argument("--timeframe", default="5m")
+    p.add_argument("--limit", type=int, default=500)
+    p.add_argument("--fast", type=int, default=20)
+    p.add_argument("--slow", type=int, default=50)
+    p.add_argument("--start-usd", type=float, default=1000.0)
+    p.add_argument("--exchange", default="binance")
+    return p.parse_args()
 
 if __name__ == "__main__":
-    run()
+    args = parse_args()
+    run(
+        symbol=args.symbol,
+        timeframe=args.timeframe,
+        limit=args.limit,
+        fast=args.fast,
+        slow=args.slow,
+        start_usd=args.start_usd,
+        exchange=args.exchange,
+    )


### PR DESCRIPTION
## Summary
- add CLI arguments and equity curve output to the trading bot
- compute max drawdown and Sharpe metrics in the backtest
- document CLI usage examples in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6f2e00c448323811d32c50cdca096