### PR TITLE
CI: basic pytest workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 numpy
 ccxt
 python-dotenv
+pytest

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is importable when tests run from the tests directory
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+def test_imports():
+    import data, strategy, paper_broker, bot  # noqa: F401
+    assert True


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs pytest
- include pytest in the requirements so the workflow can run
- add an import smoke test covering core trading modules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6f71cd4ec8323bd820dcc60ed9a9a