### PR TITLE
Feature: multi-symbol scan + markdown report

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,9 @@ Run with custom params:
 Backtest summary:
 `python backtest.py`
 
+## Multi-scan
+Run a multi-symbol scan and generate `scan_results.csv` + `report.md`:
+`python scan.py`
+
 ## Config via .env
 Copy `.env.example` to `.env` and adjust values. CLI args override .env defaults.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 ccxt
 python-dotenv
 pytest
+tabulate

--- a/scan.py
+++ b/scan.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+from bot import run
+
+
+SYMBOLS = ["BTC/USDT", "ETH/USDT", "BNB/USDT", "SOL/USDT", "XRP/USDT"]
+TIMEFRAMES = ["5m", "15m"]
+
+
+def main():
+    rows = []
+    for sym in SYMBOLS:
+        for tf in TIMEFRAMES:
+            final_eq, trades, _ = run(symbol=sym, timeframe=tf)
+            rows.append(
+                {
+                    "symbol": sym,
+                    "timeframe": tf,
+                    "final_equity": final_eq,
+                    "trades": 0 if trades is None else len(trades),
+                }
+            )
+    df = pd.DataFrame(rows)
+    df.sort_values(["final_equity"], ascending=False, inplace=True)
+    df.to_csv("scan_results.csv", index=False)
+
+    with open("report.md", "w", encoding="utf-8") as f:
+        f.write("# Scan report\n\n")
+        f.write(df.to_markdown(index=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a scan script that iterates multiple symbols/timeframes and writes CSV/Markdown reports
- document the new scan command in the README and include the tabulate dependency for Markdown export

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fc5e167483239aa1388b6c10685d