### PR TITLE
Feature: Binance LIVE mode + risk caps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,9 @@ RSI_EXIT=45
 
 TRAILING_STOP_PCT=0.02
 
-BROKER=paper      # paper | binance_testnet
+BROKER=paper            # paper | binance_testnet | binance_live
 BINANCE_API_KEY=
 BINANCE_API_SECRET=
 CLOSE_AT_END=0
+MAX_ALLOC_PCT=0.25      # max % hotovosti na 1 vstup (0.25 = 25 %)
+MAX_TRADE_USD=50        # USD strop na 1 vstup

--- a/config.py
+++ b/config.py
@@ -33,3 +33,5 @@ TRAILING_STOP_PCT = float(os.getenv("TRAILING_STOP_PCT", "0.0"))
 CLOSE_AT_END = os.getenv("CLOSE_AT_END", "0").lower() in ("1","true","yes")
 
 BROKER = os.getenv("BROKER", "paper").lower()
+MAX_ALLOC_PCT = float(os.getenv("MAX_ALLOC_PCT", "0.25"))
+MAX_TRADE_USD = float(os.getenv("MAX_TRADE_USD", "50"))

--- a/live_broker_binance.py
+++ b/live_broker_binance.py
@@ -1,14 +1,13 @@
 import ccxt
 
 
-class BinanceTestnetBroker:
-    """Market-order broker for Binance Spot TESTNET. For safety, testnet only."""
+class BinanceBroker:
+    """Market-order broker for Binance Spot (testnet or live)."""
 
     def __init__(self, api_key: str, api_secret: str, symbol: str, fee: float = 0.0005, testnet: bool = True):
         self.symbol = symbol
         self.fee = float(fee)
         self.trades = []
-        self.testnet = bool(testnet)
 
         self.exchange = ccxt.binance({
             "apiKey": api_key,
@@ -16,42 +15,35 @@ class BinanceTestnetBroker:
             "enableRateLimit": True,
             "options": {"defaultType": "spot"},
         })
-        # try sandbox mode, then hard-override URLs as fallback
-        if self.testnet:
+        if testnet:
             try:
                 self.exchange.set_sandbox_mode(True)
             except Exception:
                 pass
-        try:
-            self.exchange.urls["api"]["public"] = "https://testnet.binance.vision/api"
-            self.exchange.urls["api"]["private"] = "https://testnet.binance.vision/api"
-        except Exception:
-            pass
+            try:
+                self.exchange.urls["api"]["public"] = "https://testnet.binance.vision/api"
+                self.exchange.urls["api"]["private"] = "https://testnet.binance.vision/api"
+            except Exception:
+                pass
 
         self.exchange.load_markets()
-        self.market = self.exchange.market(self.symbol)
-        self.base = self.market["base"]  # e.g. ETH for ETH/USDT
-        self.quote = self.market["quote"]  # e.g. USDT
+        m = self.exchange.market(self.symbol)
+        self.base, self.quote = m["base"], m["quote"]
 
     def _free(self, code: str) -> float:
         bal = self.exchange.fetch_balance()
         info = bal.get(code) or {}
         return float(info.get("free", 0.0))
 
+    def quote_cash(self) -> float:
+        return self._free(self.quote)
+
     def _amt_from_usd(self, usd: float, price: float) -> float:
         raw = (usd * (1 - self.fee)) / float(price)
         return float(self.exchange.amount_to_precision(self.symbol, raw))
 
-    @property
-    def usd(self) -> float:
-        return self._free(self.quote)
-
-    @property
-    def asset(self) -> float:
-        return self._free(self.base)
-
     def buy_all(self, price: float, ts) -> None:
-        usdt = self._free(self.quote)
+        usdt = self.quote_cash()
         if usdt <= 0:
             return
         amt = self._amt_from_usd(usdt, price)
@@ -61,7 +53,7 @@ class BinanceTestnetBroker:
         self.trades.append({"ts": ts, "side": "BUY", "price": float(price), "qty": float(amt), "orderId": order.get("id")})
 
     def buy_fraction(self, price: float, ts, fraction: float) -> None:
-        usdt = self._free(self.quote)
+        usdt = self.quote_cash()
         if usdt <= 0:
             return
         spend = usdt * max(0.0, min(1.0, float(fraction)))
@@ -80,7 +72,6 @@ class BinanceTestnetBroker:
         self.trades.append({"ts": ts, "side": "SELL", "price": float(price), "qty": float(qty), "orderId": order.get("id")})
 
     def equity(self, price: float) -> float:
-        bal = self.exchange.fetch_balance()
-        usd = float((bal.get(self.quote) or {}).get("free", 0.0))
-        asset = float((bal.get(self.base) or {}).get("free", 0.0))
+        usd = self.quote_cash()
+        asset = float(self._free(self.base))
         return usd + asset * float(price)

--- a/paper_broker.py
+++ b/paper_broker.py
@@ -28,6 +28,9 @@ class PaperBroker:
         self.trades.append({"ts": ts, "side": "BUY", "price": float(price), "qty": float(qty)})
         self.usd -= spend
 
+    def quote_cash(self) -> float:
+        return float(self.usd)
+
     def sell_all(self, price: float, ts) -> None:
         if self.asset <= 0 or price <= 0:
             return


### PR DESCRIPTION
## Summary
- extend environment configuration with broker mode and allocation caps
- replace the Binance broker implementation with a unified live/testnet variant and expose cash helpers
- update the trading bot to respect allocation caps, auto-select Binance brokers, and expose paper broker cash helper

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d7122b10488323960bd885c3036874